### PR TITLE
add func to delete resource group on cluster delete

### DIFF
--- a/internal/apiserver/cluster.go
+++ b/internal/apiserver/cluster.go
@@ -165,6 +165,12 @@ func (s *Server) DeleteCluster(ctx context.Context, in *pb.DeleteClusterMsg) (*p
 	if enumeratedStatus != pb.ClusterStatus_STOPPING {
 		logger.Errorf("expected status -->%s<-- on stopping but instead received -->%s<-- on cluster -->%s<--! ... ", pb.ClusterStatus_PROVISIONING, enumeratedStatus, in.Name)
 	}
+	// delete resource group
+	groupsClient := az.GetGroupsClient(in.Credentials.Tenant, in.Credentials.AppId, in.Credentials.Password, in.Credentials.SubscriptionId)
+	deleteGroupErr := az.DeleteGroup(ctx, groupsClient, in.Name)
+	if err != nil {
+		return nil, fmt.Errorf("error deleting resource group: %v", deleteGroupErr)
+	}
 
 	return &pb.DeleteClusterReply{
 		Ok:     true,

--- a/pkg/util/azureutil/aks.go
+++ b/pkg/util/azureutil/aks.go
@@ -164,8 +164,6 @@ func (a *AKS) DeleteCluster(input DeleteClusterInput) (DeleteClusterOutput, erro
 	}
 
 	return output, err
-
-	// TODO: delete resource group also, if nothing else is in it
 }
 
 // ListClusters will list all clusters in the subscription

--- a/pkg/util/azureutil/groups.go
+++ b/pkg/util/azureutil/groups.go
@@ -68,5 +68,17 @@ func CreateGroup(ctx context.Context, groupsClient resources.GroupsClient, resou
 	return grp, nil
 }
 
-// TODO: DeleteGroup will delete a group if it is empty
-// TODO: make sure not to delete groups that contain resources still
+// DeleteGroup will delete an azure resource group
+func DeleteGroup(ctx context.Context, groupsClient resources.GroupsClient, resourceName string) error {
+	// generate resource group name based on resource name
+	resourceGroupName := resourceName + "-group"
+
+	_, err := groupsClient.Delete(
+		ctx,
+		resourceGroupName,
+	)
+	if err != nil {
+		return fmt.Errorf("error while deleting resource group %s, error message: %v", resourceGroupName, err)
+	}
+	return nil
+}


### PR DESCRIPTION
When making a request to cma-aks to delete a cluster it will now also delete the resource group. 