### PR TITLE
Ready test should check for happy case

### DIFF
--- a/test/e2e/full-test.sh
+++ b/test/e2e/full-test.sh
@@ -100,7 +100,12 @@ test_ready(){
     return 1
   fi
 
-  echo "Nodes READY"
+  if echo $nodes | grep -o Ready; then
+    echo "Node(s) Ready"
+  else
+    return 1
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
The ready_test wasn't checking for the happy case 'Ready'.  This caused it to erroneously indicate Ready when the kubectl get nodes command wasn't working (kubeconfig wasn't correct).  Now it checks that it sees the Ready condition, after checking for the most common error conditions.